### PR TITLE
review

### DIFF
--- a/hospital/src/main/resources/application.properties
+++ b/hospital/src/main/resources/application.properties
@@ -11,5 +11,6 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 
+
 # Outras configurações
 spring.datasource.initialization-mode=always


### PR DESCRIPTION
Esse site que não cadastra o paciente deve achar que estamos no século passado! Só falta pedir pra gente enviar a ficha no correio e esperar o pombo-correio voltar com a confirmação!

-O FrontEnd estava dentro da pasta do BackEnd em resources

-Não estava funcionando o sistema de cadastro do paciente, consulta e medico.

-Tinha atributos extras que não serviam pra nada, tipo tinha andares como atributo na classe consulta, sendo que não existia um campo para preencher no front.